### PR TITLE
fix path to LICENSE; expose Encode/Decode for byte[] values

### DIFF
--- a/Base62/Base62.csproj
+++ b/Base62/Base62.csproj
@@ -13,13 +13,13 @@
     <PackageReleaseNotes>UTF8 support</PackageReleaseNotes>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Version>1.1.0</Version>
     <RepositoryType></RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\FileTypeInterrogator\LICENSE.md">
+    <None Include="../LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>

--- a/Base62/Base62Converter.cs
+++ b/Base62/Base62Converter.cs
@@ -40,7 +40,7 @@ namespace Base62
             return Decode(arr);
         }
 
-        private string Encode(byte[] value)
+        public string Encode(byte[] value)
         {
             var converted = BaseConvert(value, 256, 62);
             var builder = new StringBuilder();
@@ -51,7 +51,7 @@ namespace Base62
             return builder.ToString();
         }
 
-        private string Decode(byte[] value)
+        public string Decode(byte[] value)
         {
             var converted = BaseConvert(value, 62, 256);
 


### PR DESCRIPTION
This just exposes the functions to encode/decode byte arrays (which is something I wanted to do) and also fixes the path to the LICENSE in the c# project file (it's currently pointing outside the repository at ../../FileTypeInterrogator/LICENSE.md). 

Thanks,

Mark