### PR TITLE
Fix for Issue #4

### DIFF
--- a/Base62.Tests/Base62Tests.cs
+++ b/Base62.Tests/Base62Tests.cs
@@ -55,6 +55,16 @@ namespace Base62.Tests
             Assert.Equal(input, decoded);
         }
 
+        [Fact]
+        public void FirstZeroBytesAreConvertedCorrectly()
+        {
+            var sourceBytes = new byte[] { 0, 0, 1, 2, 0, 0 };
+            var encoded = Base62Converter.BaseConvert(sourceBytes, 256, 62);
+            var decoded = Base62Converter.BaseConvert(encoded, 62, 256);
+            Assert.Equal(sourceBytes, decoded);
+
+        }
+
         public static IEnumerable<object[]> GetData()
         {
             var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "validation_data.txt");

--- a/Base62/Base62.csproj
+++ b/Base62/Base62.csproj
@@ -32,6 +32,12 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Base62.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <PropertyGroup Condition="$(Configuration) == 'Release'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/Base62/Base62Converter.cs
+++ b/Base62/Base62Converter.cs
@@ -96,11 +96,11 @@ namespace Base62
         /// <returns>Converted byte array.</returns>
         internal static byte[] BaseConvert(byte[] source, int sourceBase, int targetBase)
         {
-            if (targetBase < 0 || targetBase > 256)
-                throw new ArgumentOutOfRangeException(nameof(targetBase), targetBase, "Value must be between 1 & 256 (inclusive)");
+            if (targetBase < 2 || targetBase > 256)
+                throw new ArgumentOutOfRangeException(nameof(targetBase), targetBase, "Value must be between 2 & 256 (inclusive)");
             
-            if (sourceBase < 0 || sourceBase > 256)
-                throw new ArgumentOutOfRangeException(nameof(sourceBase), sourceBase, "Value must be between 1 & 256 (inclusive)");
+            if (sourceBase < 2 || sourceBase > 256)
+                throw new ArgumentOutOfRangeException(nameof(sourceBase), sourceBase, "Value must be between 2 & 256 (inclusive)");
 
             // Set initial capacity estimate if the size is small.
             var startCapacity = source.Length < 1028 

--- a/Base62/Base62Converter.cs
+++ b/Base62/Base62Converter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Base62
@@ -86,15 +87,46 @@ namespace Base62
             return BaseConvert(value, 62, 256);
         }
 
-        private static byte[] BaseConvert(byte[] source, int sourceBase, int targetBase)
+        /// <summary>
+        /// Converts source byte array from the source base to the destination base.
+        /// </summary>
+        /// <param name="source">Byte array to convert.</param>
+        /// <param name="sourceBase">Source base to convert from.</param>
+        /// <param name="targetBase">Target base to convert to.</param>
+        /// <returns>Converted byte array.</returns>
+        public static byte[] BaseConvert(byte[] source, int sourceBase, int targetBase)
         {
-            var result = new List<int>();
+            if (targetBase < 0 || targetBase > 256)
+                throw new ArgumentOutOfRangeException(nameof(targetBase), targetBase, "Value must be between 0 & 257");
+            
+            if (sourceBase < 0 || sourceBase > 256)
+                throw new ArgumentOutOfRangeException(nameof(sourceBase), sourceBase, "Value must be between 0 & 257");
+
+            // Set initial capacity estimate if the size is small.
+            var startCapacity = source.Length < 1028 
+                ? (int)(source.Length * 1.5) 
+                : source.Length;
+
+            var result = new List<int>(startCapacity);
+            var quotient = new List<byte>((int)(source.Length * 0.5));
             int count;
+            int initialStartOffset = 0;
+
+            // This is a bug fix for the following issue:
+            // https://github.com/ghost1face/base62/issues/4
+            while (source[initialStartOffset] == 0)
+            {
+                result.Add(0);
+                initialStartOffset++;
+            }
+
+            int startOffset = initialStartOffset;
+
             while ((count = source.Length) > 0)
             {
-                var quotient = new List<byte>();
+                quotient.Clear();
                 int remainder = 0;
-                for (var i = 0; i != count; i++)
+                for (var i = initialStartOffset; i != count; i++)
                 {
                     int accumulator = source[i] + remainder * sourceBase;
                     byte digit = (byte)((accumulator - (accumulator % targetBase)) / targetBase);
@@ -105,11 +137,13 @@ namespace Base62
                     }
                 }
 
-                result.Insert(0, remainder);
+                result.Insert(startOffset, remainder);
                 source = quotient.ToArray();
+                initialStartOffset = 0;
             }
 
             var output = new byte[result.Count];
+
             for (int i = 0; i < result.Count; i++)
                 output[i] = (byte)result[i];
 

--- a/Base62/Base62Converter.cs
+++ b/Base62/Base62Converter.cs
@@ -94,13 +94,13 @@ namespace Base62
         /// <param name="sourceBase">Source base to convert from.</param>
         /// <param name="targetBase">Target base to convert to.</param>
         /// <returns>Converted byte array.</returns>
-        public static byte[] BaseConvert(byte[] source, int sourceBase, int targetBase)
+        internal static byte[] BaseConvert(byte[] source, int sourceBase, int targetBase)
         {
             if (targetBase < 0 || targetBase > 256)
-                throw new ArgumentOutOfRangeException(nameof(targetBase), targetBase, "Value must be between 0 & 257");
+                throw new ArgumentOutOfRangeException(nameof(targetBase), targetBase, "Value must be between 1 & 256 (inclusive)");
             
             if (sourceBase < 0 || sourceBase > 256)
-                throw new ArgumentOutOfRangeException(nameof(sourceBase), sourceBase, "Value must be between 0 & 257");
+                throw new ArgumentOutOfRangeException(nameof(sourceBase), sourceBase, "Value must be between 1 & 256 (inclusive)");
 
             // Set initial capacity estimate if the size is small.
             var startCapacity = source.Length < 1028 


### PR DESCRIPTION
Addresses #4 issue with byte arrays which start with 0.  The following items are changed:
 - Base62Converter.BaseConvert() is now public.
 - Base62Converter.BaseConvert() now will prepend zero bytes to the beginning of the returned byte array.